### PR TITLE
Prevent loading mod on servers

### DIFF
--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -12,6 +12,7 @@ license="LGPL-3.0-only"
     authors="CreativeMD"
     description='''Enhances the rendering of items.'''
     displayTest="NONE"
+    side="CLIENT"
 
 [[dependencies.itemphysiclite]]
     modId="neoforge"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -10,7 +10,7 @@
     ],
     "license": "LGPL-3.0-only",
     "icon": "itemphysiclite.png",
-    "environment": "*",
+    "environment": "client",
     "entrypoints": {
         "client": [
             "team.creative.itemphysiclite.ItemPhysicLite"


### PR DESCRIPTION
This PR prevents crashes that occur when this mod is loaded on a server.
Since the mod does not have any server side entry points on fabric and is labelled as client-only on Modrinth, I just completely prevented it from loading on servers.

Here's an example crash report of this issue: https://mclo.gs/oloHuPh